### PR TITLE
feat: make chat import always available in main area

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -36,13 +36,6 @@
 			<main class="chat-area" class:hidden={$appState.isMobile && !$appState.currentChatId}>
 				{#if $currentChat}
 					<ChatView />
-				{:else if $chats.length > 0}
-					<div class="welcome-screen">
-						<div class="welcome-content">
-							<h2>Select a chat to start viewing</h2>
-							<p>Choose a chat from the sidebar to see your messages</p>
-						</div>
-					</div>
 				{:else}
 					<div class="welcome-screen">
 						<UploadArea />


### PR DESCRIPTION
Replace conditional welcome screen with permanent UploadArea access. Users can now import additional chats without needing to clear existing ones first, fixing the faulty UX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the chat view by removing the welcome message when chats exist but none are selected. The interface now shows the upload area directly if no chat is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->